### PR TITLE
Add support for private-key-jwt as option for --token-request-type

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,6 +20,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+        pip install -e '.[testing]'
+
+    - name: Test package
+      run: python -m pytest tests --cov=httpie_oauth2_client_credentials --cov-report=html:build/coverage --capture=no
 
     - name: Build package
       run: python -m build

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -1,11 +1,10 @@
-name: Upload Python Package
+name: Test Python Package
 
 on:
-  release:
-    types: [published]
+  push
 
 jobs:
-  pypi-publish:
+  testing:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout resource
@@ -20,11 +19,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+        pip install -e '.[testing]'
+
+    - name: Test package
+      run: python -m pytest tests --cov=httpie_oauth2_client_credentials --cov-report=html:build/coverage --capture=no
 
     - name: Build package
       run: python -m build
-
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 /dist
 .idea
 .env
+.coverage
+/venv

--- a/README.md
+++ b/README.md
@@ -13,6 +13,25 @@ Another option is to install from local source:
 httpie cli plugins install .
 ```
 
+## Development
+
+Create and activate a venv:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+```
+
+Install the dependencies used for testing/development:
+```
+pip install -e '.[testing]'
+```
+
+Run the tests for the project:
+```bash
+python -m pytest tests --cov=httpie_oauth2_client_credentials --cov-report=html:build/coverage --capture=no
+```
+
 ## Usage
 
 Since the format of the request to get the token depends on the support of the server, this module supports the following three patterns depending on the `--token-request-type` option.  

--- a/httpie_oauth2_client_credentials.py
+++ b/httpie_oauth2_client_credentials.py
@@ -1,15 +1,22 @@
 '''
 OAuth2.0 client credentials flow plugin for HTTPie.
 '''
-
+import os.path
 import sys
+import uuid
+from base64 import b64encode, urlsafe_b64encode
+from datetime import datetime, timedelta
 from httpie.plugins import AuthPlugin
 from httpie.cli.definition import parser as httpie_args_parser
 from urllib.request import Request, urlopen
 from urllib.parse import urlencode
 from urllib.error import HTTPError
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives import hashes
 import json
-from base64 import b64encode
+
 
 class OAuth2ClientCredentials:
 
@@ -34,30 +41,34 @@ class OAuth2ClientCredentials:
         token = token_response.get('access_token', '')
         request.headers['Authorization'] = '%s %s' % (token_type, token)
         return request
-    
+
     def __get_token(self):
         req_headers = {'Content-Type': 'application/x-www-form-urlencoded'}
         post_params = {'grant_type': 'client_credentials'}
         if self.scope:
             post_params['scope'] = self.scope
-        
+
         post_data = None
         if self.token_request_type == 'basic':
             credentials = u'%s:%s' % (self.client_id, self.client_secret)
             token = b64encode(credentials.encode('utf8')).strip().decode('latin1')
             req_headers['Authorization'] = 'Basic %s' % token
             post_data = urlencode(post_params).encode()
-
-        else:
+        elif self.token_request_type == 'form':
             post_params['client_id'] = self.client_id
             post_params['client_secret'] = self.client_secret
-            if self.token_request_type == 'form':
-                post_data = urlencode(post_params).encode()
-            elif self.token_request_type == 'json':
-                req_headers = {'Content-Type': 'application/json'}
-                post_data = json.dumps(post_params).encode("utf-8")
-            else:
-                raise ValueError('token-request-type is invalid value.')
+            post_data = urlencode(post_params).encode()
+        elif self.token_request_type == 'json':
+            req_headers = {'Content-Type': 'application/json'}
+            post_params['client_id'] = self.client_id
+            post_params['client_secret'] = self.client_secret
+            post_data = json.dumps(post_params).encode("utf-8")
+        elif self.token_request_type == 'private-key-jwt':
+            post_params['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+            post_params['client_assertion'] = self.__create_client_assertion()
+            post_data = urlencode(post_params).encode()
+        else:
+            raise ValueError('token-request-type is invalid value.')
 
         # Execute token request.
         try:
@@ -66,7 +77,7 @@ class OAuth2ClientCredentials:
             if self.print_token_response:
                 sys.stdout.write(f'token_response: \n========== \n{json.dumps(res_body, indent=2)}\n==========\n')
             return res_body
-        except HTTPError as e: 
+        except HTTPError as e:
             if self.print_token_response:
                 sys.stderr.write(f'oauth2 error response:\nstatus={e.status}\n')
                 res_body = e.read()
@@ -77,14 +88,69 @@ class OAuth2ClientCredentials:
                     sys.stderr.write(f'error_response: \n========== \n{res_body}\n==========\n')
             raise e
 
+    def __create_client_assertion(self):
+        now = datetime.now()
+        expiration_time = now + timedelta(seconds=600)  # Token is valid for 10 minutes
+
+        header = {
+            "alg": "RS256",
+            "typ": "JWT"
+        }
+
+        payload = {
+            'iss': self.client_id,
+            'sub': self.client_id,
+            'jti': str(uuid.uuid4()),
+            'aud': self.token_endpoint,
+            'exp': int(expiration_time.timestamp()),
+            'iat': int(now.timestamp()),
+        }
+
+        # Encode header and payload
+        encoded_header = urlsafe_b64encode(json.dumps(header).encode('utf-8')).rstrip(b'=')
+        encoded_payload = urlsafe_b64encode(json.dumps(payload).encode('utf-8')).rstrip(b'=')
+
+        # Create a signature using client_secret
+        signature_input = encoded_header + b'.' + encoded_payload
+
+        if self.token_request_type == 'private-key-jwt':
+            if self.client_secret.startswith('@'):
+                filename = self.client_secret[1:]
+                if not os.path.isfile(filename):
+                    raise ValueError('file "' + filename + '" is not a file')
+                with open(filename, 'rb') as key_file:
+                    certificate = key_file.read()
+            else:
+                certificate = self.client_secret.encode('ascii')
+            private_key = serialization.load_pem_private_key(
+                certificate.strip(),
+                password=None,
+                backend=default_backend()
+            )
+            # Sign the data
+            signature = private_key.sign(
+                signature_input,
+                padding.PKCS1v15(),
+                hashes.SHA256()
+            )
+        else:
+            raise ValueError('token-request-type is invalid value.')
+
+        encoded_signature = urlsafe_b64encode(signature).rstrip(b'=')
+
+        # Combine all parts to create the final JWT
+        jwt_token = encoded_header + b'.' + encoded_payload + b'.' + encoded_signature
+
+        return jwt_token.decode('utf-8')
+
 class OAuth2ClientCredentialsPlugin(AuthPlugin):
 
-    name = 'OAuth2.0 client credentilas flow.'
+    name = 'OAuth2.0 client credentials flow.'
     auth_type = 'oauth2-client-credentials'
     netrc_parse = True
     description = 'Set the Bearer token obtained in the OAuth2.0 client_credentials flow to the Authorization header.'
 
-    params = httpie_args_parser.add_argument_group(title='OAuth2.0 client credentilas flow options')
+    params = httpie_args_parser.add_argument_group(title='OAuth2.0 client credentials flow options')
     params.add_argument(
         '--token-endpoint',
         default=None,
@@ -94,7 +160,7 @@ class OAuth2ClientCredentialsPlugin(AuthPlugin):
     params.add_argument(
         '--token-request-type',
         default='basic',
-        choices=('basic','form','json'),
+        choices=('basic', 'form', 'json', 'private-key-jwt'),
         help='OAuth 2.0 Token request types.'
     )
     params.add_argument(
@@ -115,7 +181,7 @@ class OAuth2ClientCredentialsPlugin(AuthPlugin):
         '''Add to authorization header
         Args:
             username str: client_id(client_id)
-            password str: client_secret(client_sercret)
+            password str: client_secret(client_secret)
 
         Returns:
             requests.models.PreparedRequest:

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,13 @@ setup(
     url='https://github.com/satodoc/httpie-oauth2-client-credentials',
     download_url='https://github.com/satodoc/httpie-oauth2-client-credentials',
     py_modules=['httpie_oauth2_client_credentials'],
-    install_requires=['httpie>=3.2.2', 'cryptography>=42.0.3'],
+    install_requires=['httpie>=3.2.2', 'pyjwt[crypto]>=2.8.0'],
     extras_require={
-        "testing": [
-            "pyjwt",
-            "pytest",
-            "pytest-cov",
-            "pytest_httpserver",
-            "werkzeug"
+        'testing': [
+            'pytest',
+            'pytest-cov',
+            'pytest_httpserver',
+            'werkzeug'
         ]
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='https://github.com/satodoc/httpie-oauth2-client-credentials',
     download_url='https://github.com/satodoc/httpie-oauth2-client-credentials',
     py_modules=['httpie_oauth2_client_credentials'],
-    install_requires=['httpie>=3.2.2'],
+    install_requires=['httpie>=3.2.2', 'cryptography>=42.0.3'],
     entry_points={
         'httpie.plugins.auth.v1': [
             'httpie_oauth2_client_credentials = httpie_oauth2_client_credentials:OAuth2ClientCredentialsPlugin'

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,15 @@ setup(
     download_url='https://github.com/satodoc/httpie-oauth2-client-credentials',
     py_modules=['httpie_oauth2_client_credentials'],
     install_requires=['httpie>=3.2.2', 'cryptography>=42.0.3'],
+    extras_require={
+        "testing": [
+            "pyjwt",
+            "pytest",
+            "pytest-cov",
+            "pytest_httpserver",
+            "werkzeug"
+        ]
+    },
     entry_points={
         'httpie.plugins.auth.v1': [
             'httpie_oauth2_client_credentials = httpie_oauth2_client_credentials:OAuth2ClientCredentialsPlugin'

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from io import BytesIO, StringIO
+
+from httpie.context import Environment
+from httpie.core import main
+
+
+@dataclass
+class CLIResponse:
+    stdout: str
+    stderr: str
+
+
+class MockEnvironment(Environment):
+    colors = 0
+    show_displays = False
+    stdin = None
+    stdout_isatty = True
+    stderr_isatty = True
+    is_windows = False
+
+
+def http(*args) -> CLIResponse:
+    with BytesIO() as stdout, StringIO() as stderr:
+        env = MockEnvironment(stdout=stdout, stderr=stderr)
+        main(args=['http', *args], env=env)
+        env.stdout.seek(0)
+        env.stderr.seek(0)
+        out = env.stdout.read().decode('utf8')
+        err = env.stderr.read()
+        r = CLIResponse(stdout=out, stderr=err)
+    return r

--- a/tests/test_httpie_oauth2_client_credentials.py
+++ b/tests/test_httpie_oauth2_client_credentials.py
@@ -25,25 +25,18 @@ APPLICATION_JSON = 'application/json'
 APPLICATION_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded'
 SCOPE_ROLES = 'roles'
 JWT_BEARER = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
-
-
-def token_handler(assertions: Callable[[Request], None]) -> Callable[[Request], Response]:
-    def handler(request: Request):
-        assertions(request)
-        token_response = {
-            'access_token': BEARER_TOKEN,
-            'scope': 'roles',
-            'token_type': 'Bearer',
-            'expires_in': 3599
-        }
-        return Response(json.dumps(token_response))
-
-    return handler
+FIXED_TOKEN_RESPONSE = Response(status=200, response=json.dumps({
+    'access_token': BEARER_TOKEN,
+    'scope': 'roles',
+    'token_type': 'Bearer',
+    'expires_in': 3599
+}))
 
 
 def do_test(httpserver: HTTPServer,
-            assertions: Union[Callable[[Request], None] | None],
-            token_request_type: Union[str | None],
+            token_request_type: Union[str, None],
+            token_assertions: Union[Callable[[Request], None], None] = None,
+            token_response: Response = FIXED_TOKEN_RESPONSE,
             client_id: str = CLIENT_ID,
             client_secret: str = CLIENT_SECRET,
             print_token_response: bool = False):
@@ -52,9 +45,12 @@ def do_test(httpserver: HTTPServer,
     auth_ok = {'authenticated': True, 'user': CLIENT_ID}
     auth_headers = {'Authorization': f'Bearer {BEARER_TOKEN}'}
 
-    if assertions:
-        httpserver.expect_request(uri='/token', method='POST').respond_with_handler(token_handler(assertions))
+    def token_handler(request: Request):
+        if token_assertions:
+            token_assertions(request)
+        return token_response or FIXED_TOKEN_RESPONSE
 
+    httpserver.expect_request(uri='/token', method='POST').respond_with_handler(token_handler)
     httpserver.expect_request(uri='/api', method='GET', headers=auth_headers).respond_with_json(auth_ok)
 
     args = [httpserver.url_for('/api'),
@@ -84,7 +80,7 @@ def test_token_request_type_basic_is_default(httpserver: HTTPServer):
         assert request.headers['Authorization'] == BASIC_AUTH_CREDENTIALS
         assert request.form['scope'] == SCOPE_ROLES
 
-    r = do_test(httpserver, assertions, None)
+    r = do_test(httpserver, token_request_type=None, token_assertions=assertions)
     assert HTTP_OK in r.stdout
     assert len(r.stderr) == 0
 
@@ -96,7 +92,7 @@ def test_token_request_type_basic(httpserver: HTTPServer):
         assert request.form['grant_type'] == CLIENT_CREDENTIALS
         assert request.form['scope'] == SCOPE_ROLES
 
-    r = do_test(httpserver, assertions, 'basic')
+    r = do_test(httpserver, token_request_type='basic', token_assertions=assertions)
     assert HTTP_OK in r.stdout
     assert len(r.stderr) == 0
 
@@ -109,7 +105,7 @@ def test_token_request_type_form(httpserver: HTTPServer):
         assert request.form['client_secret'] == CLIENT_SECRET
         assert request.form['scope'] == SCOPE_ROLES
 
-    r = do_test(httpserver, assertions, 'form')
+    r = do_test(httpserver, token_request_type='form', token_assertions=assertions)
     assert HTTP_OK in r.stdout
     assert len(r.stderr) == 0
 
@@ -122,7 +118,7 @@ def test_token_request_type_json(httpserver: HTTPServer):
         assert request.json['client_secret'] == CLIENT_SECRET
         assert request.json['scope'] == SCOPE_ROLES
 
-    r = do_test(httpserver, assertions, 'json')
+    r = do_test(httpserver, token_request_type='json', token_assertions=assertions)
     assert HTTP_OK in r.stdout
     assert len(r.stderr) == 0
 
@@ -136,7 +132,8 @@ def test_token_request_type_private_key_jwt_when_given_secret(httpserver: HTTPSe
 
     key = generate_key()
     client_secret = key.private_key_pem.decode('utf8')
-    r = do_test(httpserver, assertions, 'private-key-jwt', client_secret=client_secret)
+    r = do_test(httpserver, token_request_type='private-key-jwt', client_secret=client_secret,
+                token_assertions=assertions)
     assert HTTP_OK in r.stdout
     assert len(r.stderr) == 0
 
@@ -153,7 +150,8 @@ def test_token_request_type_private_key_jwt_when_given_secret_file(httpserver: H
     private_key_pem_path.write_bytes(key.private_key_pem)
 
     client_secret = f'@{private_key_pem_path}'
-    r = do_test(httpserver, assertions, 'private-key-jwt', client_secret=client_secret)
+    r = do_test(httpserver, token_request_type='private-key-jwt', client_secret=client_secret,
+                token_assertions=assertions)
     assert HTTP_OK in r.stdout
     assert len(r.stderr) == 0
 
@@ -184,43 +182,34 @@ def verify_client_assertion(client_assertion: str, audience: str, public_key: RS
 
 
 def test_token_request_type_private_key_jwt_when_given_missing_file(httpserver: HTTPServer):
-    def assertions(_: Request):
-        return
-
     client_secret = '@missing_private_key.pem'
-    r = do_test(httpserver, assertions, 'private-key-jwt', client_secret=client_secret)
+    r = do_test(httpserver, token_request_type='private-key-jwt', client_secret=client_secret)
     assert HTTP_OK not in r.stdout
     assert 'ValueError: file "missing_private_key.pem" is not a file' in r.stderr
 
 
 def test_token_request_type_form_failure(httpserver: HTTPServer):
-    def assertions(_: Request):
-        raise IOError
+    token_response = Response(status=400, response=json.dumps({
+        'error': 'invalid_client',
+        'error_description': 'Client authentication failed'
+    }))
 
-    try:
-        do_test(httpserver, assertions, 'form', print_token_response=True)
-        assert 1 == 0
-    except IOError:
-        assert 0 == 0
+    r = do_test(httpserver, token_request_type='form', token_response=token_response, print_token_response=True)
+    assert len(r.stdout) == 0
+    assert '400: BAD REQUEST' in r.stderr
 
 
 def test_when_no_client_id_provided(httpserver: HTTPServer):
-    def assertions(_: Request):
-        raise IOError
-
     try:
-        do_test(httpserver, assertions, 'form', client_id='')
+        do_test(httpserver, token_request_type='form', client_id='')
         assert 1 == 0
     except ValueError as e:
         assert 'client_id is required.' in e.args
 
 
 def test_when_no_client_secret_provided(httpserver: HTTPServer):
-    def assertions(_: Request):
-        raise IOError
-
     try:
-        do_test(httpserver, assertions, 'form', client_secret='')
+        do_test(httpserver, token_request_type='form', client_secret='')
         assert 1 == 0
     except ValueError as e:
         assert 'client_secret is required.' in e.args

--- a/tests/test_httpie_oauth2_client_credentials.py
+++ b/tests/test_httpie_oauth2_client_credentials.py
@@ -1,0 +1,226 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Union
+
+import jwt
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from httpie.plugins.registry import plugin_manager
+from pytest_httpserver import HTTPServer
+from werkzeug.wrappers import Request, Response
+
+from fixtures import http
+from httpie_oauth2_client_credentials import OAuth2ClientCredentialsPlugin
+
+HTTP_OK = '200 OK'
+BEARER_TOKEN = 'XYZ'
+CLIENT_CREDENTIALS = 'client_credentials'
+CLIENT_ID = 'client-id'
+CLIENT_SECRET = 'client-secret'
+BASIC_AUTH_CREDENTIALS = 'Basic Y2xpZW50LWlkOmNsaWVudC1zZWNyZXQ='
+APPLICATION_JSON = 'application/json'
+APPLICATION_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded'
+SCOPE_ROLES = 'roles'
+JWT_BEARER = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+
+
+def token_handler(assertions: Callable[[Request], None]) -> Callable[[Request], Response]:
+    def handler(request: Request):
+        assertions(request)
+        token_response = {
+            'access_token': BEARER_TOKEN,
+            'scope': 'roles',
+            'token_type': 'Bearer',
+            'expires_in': 3599
+        }
+        return Response(json.dumps(token_response))
+
+    return handler
+
+
+def do_test(httpserver: HTTPServer,
+            assertions: Union[Callable[[Request], None] | None],
+            token_request_type: Union[str | None],
+            client_id: str = CLIENT_ID,
+            client_secret: str = CLIENT_SECRET,
+            print_token_response: bool = False):
+    httpserver.clear()
+
+    auth_ok = {'authenticated': True, 'user': CLIENT_ID}
+    auth_headers = {'Authorization': f'Bearer {BEARER_TOKEN}'}
+
+    if assertions:
+        httpserver.expect_request(uri='/token', method='POST').respond_with_handler(token_handler(assertions))
+
+    httpserver.expect_request(uri='/api', method='GET', headers=auth_headers).respond_with_json(auth_ok)
+
+    args = [httpserver.url_for('/api'),
+            '--auth-type', OAuth2ClientCredentialsPlugin.auth_type,
+            '--auth', f'{client_id}:{client_secret}',
+            '--token-endpoint', httpserver.url_for('/token'),
+            '--scope', 'roles']
+
+    if token_request_type:
+        args.append('--token-request-type')
+        args.append(token_request_type)
+
+    if print_token_response:
+        args.append('--print-token-response')
+
+    plugin_manager.register(OAuth2ClientCredentialsPlugin)
+    try:
+        return http(*args)
+    finally:
+        httpserver.check()
+        plugin_manager.unregister(OAuth2ClientCredentialsPlugin)
+
+
+def test_token_request_type_basic_is_default(httpserver: HTTPServer):
+    def assertions(request: Request):
+        assert request.headers['Content-Type'] == APPLICATION_WWW_FORM_URLENCODED
+        assert request.headers['Authorization'] == BASIC_AUTH_CREDENTIALS
+        assert request.form['scope'] == SCOPE_ROLES
+
+    r = do_test(httpserver, assertions, None)
+    assert HTTP_OK in r.stdout
+    assert len(r.stderr) == 0
+
+
+def test_token_request_type_basic(httpserver: HTTPServer):
+    def assertions(request: Request):
+        assert request.headers['Content-Type'] == APPLICATION_WWW_FORM_URLENCODED
+        assert request.headers['Authorization'] == BASIC_AUTH_CREDENTIALS
+        assert request.form['grant_type'] == CLIENT_CREDENTIALS
+        assert request.form['scope'] == SCOPE_ROLES
+
+    r = do_test(httpserver, assertions, 'basic')
+    assert HTTP_OK in r.stdout
+    assert len(r.stderr) == 0
+
+
+def test_token_request_type_form(httpserver: HTTPServer):
+    def assertions(request: Request):
+        assert request.headers['Content-Type'] == APPLICATION_WWW_FORM_URLENCODED
+        assert request.form['grant_type'] == CLIENT_CREDENTIALS
+        assert request.form['client_id'] == CLIENT_ID
+        assert request.form['client_secret'] == CLIENT_SECRET
+        assert request.form['scope'] == SCOPE_ROLES
+
+    r = do_test(httpserver, assertions, 'form')
+    assert HTTP_OK in r.stdout
+    assert len(r.stderr) == 0
+
+
+def test_token_request_type_json(httpserver: HTTPServer):
+    def assertions(request: Request):
+        assert request.headers['Content-Type'] == APPLICATION_JSON
+        assert request.json['grant_type'] == CLIENT_CREDENTIALS
+        assert request.json['client_id'] == CLIENT_ID
+        assert request.json['client_secret'] == CLIENT_SECRET
+        assert request.json['scope'] == SCOPE_ROLES
+
+    r = do_test(httpserver, assertions, 'json')
+    assert HTTP_OK in r.stdout
+    assert len(r.stderr) == 0
+
+
+def test_token_request_type_private_key_jwt_when_given_secret(httpserver: HTTPServer):
+    def assertions(request: Request):
+        assert request.headers['Content-Type'] == APPLICATION_WWW_FORM_URLENCODED
+        assert request.form['grant_type'] == CLIENT_CREDENTIALS
+        assert request.form['client_assertion_type'] == JWT_BEARER
+        verify_client_assertion(request.form['client_assertion'], httpserver.url_for('/token'), key.public_key)
+
+    key = generate_key()
+    client_secret = key.private_key_pem.decode('utf8')
+    r = do_test(httpserver, assertions, 'private-key-jwt', client_secret=client_secret)
+    assert HTTP_OK in r.stdout
+    assert len(r.stderr) == 0
+
+
+def test_token_request_type_private_key_jwt_when_given_secret_file(httpserver: HTTPServer, tmp_path):
+    def assertions(request: Request):
+        assert request.headers['Content-Type'] == APPLICATION_WWW_FORM_URLENCODED
+        assert request.form['grant_type'] == CLIENT_CREDENTIALS
+        assert request.form['client_assertion_type'] == JWT_BEARER
+        verify_client_assertion(request.form['client_assertion'], httpserver.url_for('/token'), key.public_key)
+
+    key = generate_key()
+    private_key_pem_path = Path(tmp_path / 'private_key.pem')
+    private_key_pem_path.write_bytes(key.private_key_pem)
+
+    client_secret = f'@{private_key_pem_path}'
+    r = do_test(httpserver, assertions, 'private-key-jwt', client_secret=client_secret)
+    assert HTTP_OK in r.stdout
+    assert len(r.stderr) == 0
+
+
+@dataclass
+class GeneratedKey:
+    private_key_pem: bytes
+    public_key: RSAPublicKey
+
+
+def generate_key():
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend()
+    )
+    public_key = private_key.public_key()
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption()
+    )
+    return GeneratedKey(private_key_pem, public_key)
+
+
+def verify_client_assertion(client_assertion: str, audience: str, public_key: RSAPublicKey):
+    jwt.decode(client_assertion, issuer=CLIENT_ID, audience=audience, algorithms='RS256', verify=True, key=public_key)
+
+
+def test_token_request_type_private_key_jwt_when_given_missing_file(httpserver: HTTPServer):
+    def assertions(_: Request):
+        return
+
+    client_secret = '@missing_private_key.pem'
+    r = do_test(httpserver, assertions, 'private-key-jwt', client_secret=client_secret)
+    assert HTTP_OK not in r.stdout
+    assert 'ValueError: file "missing_private_key.pem" is not a file' in r.stderr
+
+
+def test_token_request_type_form_failure(httpserver: HTTPServer):
+    def assertions(_: Request):
+        raise IOError
+
+    try:
+        do_test(httpserver, assertions, 'form', print_token_response=True)
+        assert 1 == 0
+    except IOError:
+        assert 0 == 0
+
+
+def test_when_no_client_id_provided(httpserver: HTTPServer):
+    def assertions(_: Request):
+        raise IOError
+
+    try:
+        do_test(httpserver, assertions, 'form', client_id='')
+        assert 1 == 0
+    except ValueError as e:
+        assert 'client_id is required.' in e.args
+
+
+def test_when_no_client_secret_provided(httpserver: HTTPServer):
+    def assertions(_: Request):
+        raise IOError
+
+    try:
+        do_test(httpserver, assertions, 'form', client_secret='')
+        assert 1 == 0
+    except ValueError as e:
+        assert 'client_secret is required.' in e.args

--- a/tests/test_httpie_oauth2_client_credentials.py
+++ b/tests/test_httpie_oauth2_client_credentials.py
@@ -185,7 +185,7 @@ def test_token_request_type_private_key_jwt_when_given_missing_file(httpserver: 
     client_secret = '@missing_private_key.pem'
     r = do_test(httpserver, token_request_type='private-key-jwt', client_secret=client_secret)
     assert HTTP_OK not in r.stdout
-    assert 'ValueError: file "missing_private_key.pem" is not a file' in r.stderr
+    assert 'ValueError: client_secret "@missing_private_key.pem" is not a file' in r.stderr
 
 
 def test_token_request_type_form_failure(httpserver: HTTPServer):


### PR DESCRIPTION
We found your httpie auth plugin for fetching and using OAuth JWT tokens.

The Identity Provider we use (ForgeRock) supports the private-key-jwt Client Authentication method as defined by
- [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)
- [JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants](https://www.rfc-editor.org/rfc/rfc7523.html)

This MR would be to add support for that token-request-type in this library, such that others can also benefit.
I am also willing to add tests to the MR to ensure that this functionality keeps working as expected, but wanted to first ask what would be the preferred method.